### PR TITLE
Namespace switch on exec fixed

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	outfile := utils.GetFileName(*sout)
 
-	cmd.RunCmds(pl, *run, *sout, *generateGraph, outfile)
+	cmd.RunCmds(pl, *run, *sout, *generateGraph, outfile, *nameSpace)
 
 }
 


### PR DESCRIPTION
Iperf and netperf tests would only exec into default namespace, the following PR fixes this issue.