### PR TITLE
7 use waitgroups

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mainak90/perftest/pkg/utils"
 	"k8s.io/client-go/kubernetes"
 	"strings"
+	"sync"
 )
 
 func RunNetPerf(client *kubernetes.Clientset, mode string, host string, time string, pod string, namespace string) (string, error) {
@@ -31,12 +32,17 @@ func RunNetPerfSets(deploy k8s.Podlist, graph bool, outfile string, namespace st
 			logging.WarnLog(fmt.Sprintf("Cannot fetch pod ip for pod %s skipping this one...", pod))
 			continue
 		}
+		var wg1, wg2 sync.WaitGroup
+		wg1.Add(len(deploy.PodIps) - 1)
+		wg2.Add(len(deploy.PodIps) - 1)
 		for _, ip := range deploy.PodIps {
 			if ip != podIp {
-				GenerateNetperfResult(deploy, "TCP_RR", ip, pod, namespace, tcp_rr, netpTcpRR)
-				GenerateNetperfResult(deploy, "TCP_CRR", ip, pod, namespace, tcp_crr, netpTcpCRR)
+				go GenerateNetperfResult(deploy, "TCP_RR", ip, pod, namespace, tcp_rr, netpTcpRR, &wg1)
+				go GenerateNetperfResult(deploy, "TCP_CRR", ip, pod, namespace, tcp_crr, netpTcpCRR, &wg2)
 			}
 		}
+		wg1.Wait()
+		wg2.Wait()
 		if graph {
 			generator.RenderChart(fmt.Sprintf("%s_TCP_RR.csv", pod), "TCP_RR")
 			generator.RenderChart(fmt.Sprintf("%s_TCP_CRR.csv", pod), "TCP_CRR")
@@ -66,11 +72,14 @@ func RunIperfSets(deploy k8s.Podlist, graph bool, outfile string, namespace stri
 			logging.WarnLog(fmt.Sprintf("Cannot fetch pod ip for pod %s skipping this one...", pod))
 			continue
 		}
+		var wg sync.WaitGroup
+		wg.Add(len(deploy.PodIps) - 1)
 		for _, ip := range deploy.PodIps {
 			if ip != podIp {
-				GenerateIperfResult(deploy, ip, pod, namespace, iperf, IperfMap)
+				go GenerateIperfResult(deploy, ip, pod, namespace, iperf, IperfMap, &wg)
 			}
 		}
+		wg.Wait()
 		if graph {
 			generator.RenderChart(fmt.Sprintf("%s_iperf.csv", pod), "iperf")
 		}
@@ -78,7 +87,8 @@ func RunIperfSets(deploy k8s.Podlist, graph bool, outfile string, namespace stri
 	utils.IPerfOutPut(IperfMap, outfile)
 }
 
-func GenerateNetperfResult(deploy k8s.Podlist, test string, hostip string, podname string, namespace string, testResultSet []string, netout map[string][][]string) {
+func GenerateNetperfResult(deploy k8s.Podlist, test string, hostip string, podname string, namespace string, testResultSet []string, netout map[string][][]string, wg *sync.WaitGroup) {
+	defer wg.Done()
 	logging.InfoLog(fmt.Sprintf("Running netperf test mode %s on pod %s -> IP %s ", test, podname, hostip))
 	result, err := RunNetPerf(deploy.ClientSet, test, hostip, "2", podname, namespace)
 	if err != nil {
@@ -90,7 +100,8 @@ func GenerateNetperfResult(deploy k8s.Podlist, test string, hostip string, podna
 	generator.WriteCSV(podname, test, csvLine)
 }
 
-func GenerateIperfResult(deploy k8s.Podlist, hostip string, podname string, namespace string, testResultSet []string, netout map[string][][]string) {
+func GenerateIperfResult(deploy k8s.Podlist, hostip string, podname string, namespace string, testResultSet []string, netout map[string][][]string, wg *sync.WaitGroup) {
+	defer wg.Done()
 	logging.InfoLog(fmt.Sprintf("Running iperf test on pod %s -> IP %s ", podname, hostip))
 	result, err := RunIPerf(deploy.ClientSet, hostip, "2", podname, namespace)
 	if err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -33,10 +33,10 @@ func RunNetPerfSets(deploy k8s.Podlist, graph bool, outfile string, namespace st
 			continue
 		}
 		var wg1, wg2 sync.WaitGroup
-		wg1.Add(len(deploy.PodIps) - 1)
-		wg2.Add(len(deploy.PodIps) - 1)
 		for _, ip := range deploy.PodIps {
 			if ip != podIp {
+				wg1.Add(1)
+				wg2.Add(1)
 				go GenerateNetperfResult(deploy, "TCP_RR", ip, pod, namespace, tcp_rr, netpTcpRR, &wg1)
 				go GenerateNetperfResult(deploy, "TCP_CRR", ip, pod, namespace, tcp_crr, netpTcpCRR, &wg2)
 			}
@@ -73,9 +73,9 @@ func RunIperfSets(deploy k8s.Podlist, graph bool, outfile string, namespace stri
 			continue
 		}
 		var wg sync.WaitGroup
-		wg.Add(len(deploy.PodIps) - 1)
 		for _, ip := range deploy.PodIps {
 			if ip != podIp {
+				wg.Add(1)
 				go GenerateIperfResult(deploy, ip, pod, namespace, iperf, IperfMap, &wg)
 			}
 		}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -108,7 +108,7 @@ func GenerateIperfResult(deploy k8s.Podlist, hostip string, podname string, name
 		logging.ErrLog(fmt.Sprintf("Encountered error while running iperf on pod %s %s", podname, err.Error()))
 	}
 	testResultSet = append(testResultSet, result)
-	csvLine := utils.NetperfGenerateCSVLines(deploy.IPPodMap[hostip], result)
+	csvLine := utils.IperfGenerateCSVLines(deploy.IPPodMap[hostip], result)
 	netout[podname] = append(netout[podname], strings.Split(csvLine, ","))
 	generator.WriteCSV(podname, "iperf", csvLine)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -69,22 +69,23 @@ func StripIperfOutput(str string) string {
 }
 
 func NetperfGenerateCSVLines(pod string, units string) string {
+	logging.WarnLog(fmt.Sprintf("Splitting units %s", units))
 	elements := strings.Split(units, ",")
 	p50iter, err := strconv.Atoi(strings.ReplaceAll(strings.ReplaceAll(elements[0], "\r", ""), "\n", ""))
 	if err != nil {
-		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf %v", err.Error()))
+		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf for pod %s %v", pod, err.Error()))
 	}
 	p90iter, err := strconv.Atoi(elements[1])
 	if err != nil {
-		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf %v", err.Error()))
+		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf for pod %s %v", pod, err.Error()))
 	}
 	p99iter, err := strconv.Atoi(elements[2])
 	if err != nil {
-		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf %v", err.Error()))
+		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf for pod %s %v", pod, err.Error()))
 	}
 	transiter, err := strconv.ParseFloat(elements[3], 64)
 	if err != nil {
-		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf %v", err.Error()))
+		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf for pod %s %v", pod, err.Error()))
 	}
 	return fmt.Sprintf("%s,%v,%v,%v,%v", pod, p50iter, p90iter, p99iter, transiter)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -70,15 +70,27 @@ func StripIperfOutput(str string) string {
 
 func NetperfGenerateCSVLines(pod string, units string) string {
 	elements := strings.Split(units, ",")
-	p50iter, _ := strconv.Atoi(strings.ReplaceAll(strings.ReplaceAll(elements[0], "\r", ""), "\n", ""))
-	p90iter, _ := strconv.Atoi(elements[1])
-	p99iter, _ := strconv.Atoi(elements[2])
-	transiter, _ := strconv.ParseFloat(elements[3], 64)
-	return fmt.Sprintf("%s,%v,%v,%v,%v",pod, p50iter,p90iter,p99iter,transiter)
+	p50iter, err := strconv.Atoi(strings.ReplaceAll(strings.ReplaceAll(elements[0], "\r", ""), "\n", ""))
+	if err != nil {
+		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf %v", err.Error()))
+	}
+	p90iter, err := strconv.Atoi(elements[1])
+	if err != nil {
+		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf %v", err.Error()))
+	}
+	p99iter, err := strconv.Atoi(elements[2])
+	if err != nil {
+		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf %v", err.Error()))
+	}
+	transiter, err := strconv.ParseFloat(elements[3], 64)
+	if err != nil {
+		logging.ErrLog(fmt.Sprintf("Encountered errors while generating CSV lines for netperf %v", err.Error()))
+	}
+	return fmt.Sprintf("%s,%v,%v,%v,%v", pod, p50iter, p90iter, p99iter, transiter)
 }
 
 func IperfGenerateCSVLines(pod string, unit string) string {
-	return fmt.Sprintf("%s,%s",pod,unit)
+	return fmt.Sprintf("%s,%s", pod, unit)
 }
 
 func NetPerfOutPut(input map[string][][]string, check string, out string) {


### PR DESCRIPTION
1. Added waitgroups.
2. Now all test lines from one single pod to other ips are all calculated concurrently.
3. Each pod operation(iperf, netperf) is now simultaneous than sequenced.

Sequential runtime
```
time ./bin/perftest -run all -stdout true -graph true
real	3m26.622s
user	0m0.858s
sys	0m0.311s
```

runtime with waitgroups
```
time ./bin/perftest -run all -stdout true -graph true
real	0m44.819s
user	0m0.905s
sys	0m0.174s
```